### PR TITLE
Fix date conversion in chart range update

### DIFF
--- a/components/charts/interactive-chart.tsx
+++ b/components/charts/interactive-chart.tsx
@@ -324,11 +324,18 @@ function InteractiveChartComponent({
     document.addEventListener('chart-crosshair-move', handleCrosshairMove);
 
     // Listen for time range selection
+    const timeToDate = (t: Time): Date => {
+      if (typeof t === 'number') return new Date(t * 1000);
+      if (typeof t === 'string') return new Date(t);
+      const { year, month, day } = t as { year: number; month: number; day: number };
+      return new Date(year, month - 1, day);
+    };
+
     chart.timeScale().subscribeVisibleTimeRangeChange((timeRange) => {
       if (timeRange) {
         // Update global state with selected time range
-        const from = new Date(timeRange.from as number * 1000);
-        const to = new Date(timeRange.to as number * 1000);
+        const from = timeToDate(timeRange.from as Time);
+        const to = timeToDate(timeRange.to as Time);
         setDateRange(from, to);
       }
     });


### PR DESCRIPTION
## Summary
- correct time range conversion to handle string or BusinessDay values in `InteractiveChart`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684072e13c7c8323a381d452add83659