### PR TITLE
Fix client env validation

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,38 +1,53 @@
 import { z } from 'zod';
 
+// Determine if the code is running on the server. During client-side
+// execution `window` is defined and server-only environment variables are
+// stripped out by Next.js. We use this flag to avoid requiring server-only
+// variables in the browser bundle.
+const isServer = typeof window === 'undefined';
+
 /**
  * Environment variable validation schema using Zod
  * - Required variables must be present for the app to function
  * - Optional variables will use fallbacks if not present
  */
-const envSchema = z.object({
+// Base schema shared between server and client environments. Server-only
+// variables are appended when running on the server.
+const baseEnvSchema = z.object({
   // Supabase configuration (required)
   NEXT_PUBLIC_SUPABASE_URL: z.string().url('NEXT_PUBLIC_SUPABASE_URL must be a valid URL'),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1, 'NEXT_PUBLIC_SUPABASE_ANON_KEY is required'),
-  
-  // Service role key (server-only, required for admin operations)
-  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1, 'SUPABASE_SERVICE_ROLE_KEY is required'),
-  
+
   // Node environment
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  
+
   // Optional configuration with defaults
   NEXT_PUBLIC_APP_URL: z.string().url().optional().default('http://localhost:3000'),
 });
+
+// Extend the base schema with server-only variables when running on the server.
+const serverEnvSchema = baseEnvSchema.extend({
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1, 'SUPABASE_SERVICE_ROLE_KEY is required'),
+});
+
+type ServerEnv = z.infer<typeof serverEnvSchema>;
+type ClientEnv = z.infer<typeof baseEnvSchema>;
 
 /**
  * Parse and validate environment variables
  * This will throw an error if required variables are missing or invalid
  */
-function validateEnv() {
+function validateEnv(): ServerEnv | ClientEnv {
   try {
     // Use process.env values or undefined for type safety
-    const env = envSchema.parse({
+    const schema = isServer ? serverEnvSchema : baseEnvSchema;
+
+    const env = schema.parse({
       NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
       NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
       NODE_ENV: process.env.NODE_ENV,
       NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+      ...(isServer && { SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY }),
     });
     
     return env;
@@ -57,9 +72,10 @@ function validateEnv() {
       }
     }
     
-    // Return a type-safe empty object that will fail when used
-    // This allows development to continue with proper error messages
-    return {} as ReturnType<typeof envSchema.parse>;
+    // Return a type-safe empty object that will fail when used. Using the
+    // server schema ensures all variables are typed while avoiding exposure on
+    // the client.
+    return {} as ServerEnv;
   }
 }
 
@@ -73,12 +89,12 @@ export const env = validateEnv();
  * Server-only environment variables
  * These should only be imported in server components or API routes
  */
-export const serverOnlyEnv = {
-  SUPABASE_SERVICE_ROLE_KEY: env.SUPABASE_SERVICE_ROLE_KEY,
-};
+export const serverOnlyEnv = isServer
+  ? { SUPABASE_SERVICE_ROLE_KEY: (env as ServerEnv).SUPABASE_SERVICE_ROLE_KEY }
+  : { SUPABASE_SERVICE_ROLE_KEY: undefined as never };
 
 // Export types for environment variables
-export type Env = ReturnType<typeof validateEnv>;
+export type Env = ServerEnv | ClientEnv;
 export type ServerOnlyEnv = typeof serverOnlyEnv;
 
 // Validate environment variables at startup


### PR DESCRIPTION
## Summary
- avoid requiring service role key when running in the browser
- handle client/server env schemas separately

## Testing
- `npm test` *(fails: 403 Forbidden)*
- `python3 run_test.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ea9ea2a4083239d819de4efb77a1d